### PR TITLE
Remove the multiplicated plugin name in the plugin path

### DIFF
--- a/world_launcher/CMakeLists.txt
+++ b/world_launcher/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(ignition-fuel_tools7 REQUIRED)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${IGNITION-GUI_CXX_FLAGS} ${IGNITION-FUEL_TOOLS_CXX_FLAGS}")
 
 # Set Mov.Ai Ignition docker plugins library directory
-# set(CMAKE_LIBRARY_OUTPUT_DIRECTORY /movai_ign_plugins/plugins/gui)
+# set(CMAKE_LIBRARY_OUTPUT_DIRECTORY /movai_ign_plugins/gui)
 
 QT5_ADD_RESOURCES(resources_RCC WorldLauncher.qrc)
 

--- a/world_launcher/debian/install
+++ b/world_launcher/debian/install
@@ -1,1 +1,1 @@
-./build/libWorldLauncher.so /movai_ign_plugins/plugins/gui/
+./build/libWorldLauncher.so /movai_ign_plugins/gui/


### PR DESCRIPTION
Bugfix: Remove multiple plugins in the path.