### PR TITLE
Fix/fp 1370 app issues

### DIFF
--- a/world_launcher/WorldLauncher.cc
+++ b/world_launcher/WorldLauncher.cc
@@ -103,31 +103,45 @@ void WorldLauncher::LoadFuelList()
   // Thread to not block the app
   std::thread threadLoadFuel([this]
                              {
-                  // Setup ClientConfig.
-                  ignition::fuel_tools::ClientConfig conf;
-                  conf.SetUserAgent("ExampleList");
-                  // Instantiate the FuelClient object with the configuration.
-                  ignition::fuel_tools::FuelClient client(conf);
-                  auto servers = client.Config().Servers();
-                  this->fuelWorldsList.clear();
-                  for (const auto &server : servers)
-                  {
-                    for (auto iter = client.Worlds(server); iter; ++iter)
-                    {
-                      if (iter->Owner() == this->ownerName)
-                      {
-                        // Insert the world url to the list in GUI
-                        this->fuelWorldsList.push_back(QString::fromStdString(iter->UniqueName()));
-                      }
-                    }
-                  }
-                  this->fuelWorldsList.sort(Qt::CaseInsensitive);
-                  // Inform GUI a update in the Q_PROPERTY
-                  this->FuelWorldsListChanged();
-                  SetFuelWorld(this->fuelWorldsList[0]);
-                  std::cout << "Finished " << std::endl;
-                  this->loadingStatus = false;
-                  this->LoadingStatusChanged(); });
+                               // Setup ClientConfig.
+                               ignition::fuel_tools::ClientConfig conf;
+                               conf.SetUserAgent("ExampleList");
+                               // Instantiate the FuelClient object with the configuration.
+                               ignition::fuel_tools::FuelClient client(conf);
+                               auto servers = client.Config().Servers();
+                               this->fuelWorldsList.clear();
+                               for (const auto &server : servers)
+                               {
+                                 for (auto iter = client.Worlds(server); iter; ++iter)
+                                 {
+                                   if (iter->Owner() == this->ownerName)
+                                   {
+                                     // Insert the world url to the list in GUI
+                                     this->fuelWorldsList.push_back(QString::fromStdString(iter->UniqueName()));
+                                   }
+                                 }
+                               }
+                              //  Check if there is worlds of this owner in FUEL
+                               if (this->fuelWorldsList.isEmpty())
+                               {
+                                 this->fuelWorldsList.push_back(QString::fromStdString("This Owner does not have worlds on Fuel available"));
+                                //  Blocks the Start Button
+                                 this->validFuelWorld = false;
+                                 this->ValidFuelWorldChanged();
+                               }
+                               else
+                               {
+                                //  Sort by name
+                                 this->fuelWorldsList.sort(Qt::CaseInsensitive);
+                                 SetFuelWorld(this->fuelWorldsList[0]);
+                                 this->validFuelWorld = true;
+                                 this->ValidFuelWorldChanged();
+                               }
+                               // Inform GUI a update in the Q_PROPERTY
+                               this->FuelWorldsListChanged();
+                               this->loadingStatus = false;
+                               this->LoadingStatusChanged();
+                               std::cout << "Finished " << std::endl; });
   threadLoadFuel.detach();
 }
 
@@ -178,6 +192,22 @@ void WorldLauncher::SetSimulationStatus(const bool _status)
 {
   this->simulationStatus = _status;
   this->SimulationStatusChanged();
+}
+
+/////////////////////////////////////////////////
+/// \brief Called by Ignition GUI when QBool is instantiated.
+bool WorldLauncher::ValidFuelWorld() const
+{
+  return this->validFuelWorld;
+}
+
+/////////////////////////////////////////////////
+/// \brief Called by Ignition GUI when QBool is instantiated.
+/// \param[in] _status QBool to update
+void WorldLauncher::SetValidFuelWorld(const bool _status)
+{
+  this->validFuelWorld = _status;
+  this->ValidFuelWorldChanged();
 }
 
 /////////////////////////////////////////////////
@@ -246,32 +276,34 @@ void WorldLauncher::OnFuelButton()
 
 /////////////////////////////////////////////////
 /// \brief Starts the simulator using POPEN function.
-/// \param[in] full_exec string to start the POPEN cmd.
+/// \param[in] _cmd string to start the POPEN cmd.
 /// \return Returns string of the buffer used.
 std::string WorldLauncher::StartSimulator(const std::string &_cmd)
 {
-  // Launch the selected world using popen
   std::string full_exec = _cmd;
   this->simulationResult = "";
+  // Start a thread to avoid block the app during the Simulation
   std::thread threadStartSimulator([this, full_exec]
                                    {
                                 char buffer[128];
+                                // Blocks the Start button to avoid duplicated simulations
                                 this->simulationStatus = false;
                                 this->SimulationStatusChanged();
+                                // Launch the selected world using popen
+                                FILE *processSim = popen(full_exec.c_str(), "r");
 
-                                FILE *pipe = popen(full_exec.c_str(), "r");
-
-                                if (!pipe)
+                                if (!processSim)
                                   return "ERROR";
-
-                                while (!feof(pipe))
+                                // Collect the results of the simulation
+                                while (!feof(processSim))
                                 {
-                                  if (fgets(buffer, 128, pipe) != nullptr)
+                                  if (fgets(buffer, 128, processSim) != nullptr)
                                   {
                                     this->simulationResult += buffer;
                                   }
                                 }
-                                pclose(pipe); 
+                                pclose(processSim);
+                                // Unblock the Start button
                                 this->simulationStatus = true;
                                 this->SimulationStatusChanged(); 
                                 std::cout << "Simulation result " + this->simulationResult << std::endl; });

--- a/world_launcher/WorldLauncher.hh
+++ b/world_launcher/WorldLauncher.hh
@@ -44,6 +44,13 @@ namespace ignition
                   WRITE SetSimulationStatus
                       NOTIFY SimulationStatusChanged)
 
+      /// \brief Valid world Fuel List GUI QT object.
+      Q_PROPERTY(
+          bool validFuelWorld
+              READ ValidFuelWorld
+                  WRITE SetValidFuelWorld
+                      NOTIFY ValidFuelWorldChanged)
+
       /// \brief Constructor.
     public:
       WorldLauncher();
@@ -93,6 +100,15 @@ namespace ignition
       /// \param[in] _status QBool to update
       Q_INVOKABLE void SetSimulationStatus(const bool _status);
 
+      /////////////////////////////////////////////////
+      /// \brief Called by Ignition GUI when QBool is instantiated.
+      Q_INVOKABLE bool ValidFuelWorld() const;
+
+      /////////////////////////////////////////////////
+      /// \brief Called by Ignition GUI when QBool is instantiated.
+      /// \param[in] _status QBool to update
+      Q_INVOKABLE void SetValidFuelWorld(const bool _status);
+
       /// \brief Selected local world file.
       std::string worldName{"empty.sdf"};
 
@@ -100,7 +116,7 @@ namespace ignition
       std::string fuelWorldName{"empty"};
 
       /// \brief Selected Owner of worlds on Fuel.
-      std::string ownerName{"openrobotics"};
+      std::string ownerName{"movai"};
 
       std::string simulationResult{""};
 
@@ -116,6 +132,9 @@ namespace ignition
       /// \brief Status of Simulation.
       bool simulationStatus{true};
 
+      /// \brief Valid world list from Fuel.
+      bool validFuelWorld{false};
+
     signals:
       /// \brief Notify that the worlds list has changed
       void WorldsListChanged();
@@ -128,6 +147,9 @@ namespace ignition
 
       /// \brief Notify that the Simulation status has changed
       void SimulationStatusChanged();
+
+      /// \brief Notify that the Simulation status has changed
+      void ValidFuelWorldChanged();
 
     protected slots:
       /////////////////////////////////////////////////

--- a/world_launcher/WorldLauncher.qml
+++ b/world_launcher/WorldLauncher.qml
@@ -91,7 +91,7 @@ GridLayout {
             Layout.column: 2
             Layout.row: 1
             id: topicField
-            text: "openrobotics"
+            text: "movai"
             placeholderText: qsTr("Owner of the Worlds")
             onEditingFinished: {
               WorldLauncher.OnOwnerSelection(text)
@@ -141,7 +141,7 @@ GridLayout {
               id: fuelButton
               text: qsTr("Start Simulator")
               highlighted: true
-              enabled: WorldLauncher.simulationStatus && !WorldLauncher.loadingStatus
+              enabled: WorldLauncher.simulationStatus && !WorldLauncher.loadingStatus && WorldLauncher.validFuelWorld
               onClicked: {
                 WorldLauncher.OnFuelButton();
               }


### PR DESCRIPTION

- Add thread to launch the simulator
- Create a block to the start simulator button while the simulation is running
- Block the start button if there is no Fuel worlds available of the selected owner