### PR TITLE
force combobox to the first index after refresh list

### DIFF
--- a/world_launcher/WorldLauncher.qml
+++ b/world_launcher/WorldLauncher.qml
@@ -307,6 +307,7 @@ GridLayout {
                 Material.background: Material.primary
                 onClicked: {
                   WorldLauncher.LoadLocalList();
+                  localCombo.currentIndex = 0;
                 }
                 ToolTip.visible: hovered
                 ToolTip.delay: tooltipDelay


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixing bug [DP-706](https://movai.atlassian.net/browse/DP-706) reported.
Changes:
Forces the qml combobox of local worlds to go back to the first index of the list after refresh data.

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
