### PR TITLE
Update spawn and remove plugins

### DIFF
--- a/battery_station/debian/changelog
+++ b/battery_station/debian/changelog
@@ -1,4 +1,4 @@
-movai-ign-plugin-battery-station (1.0.1-7) UNRELEASED; urgency=medium
+movai-ign-plugin-battery-station (1.0.2-0) UNRELEASED; urgency=medium
 
   [ Filipe ]
   * Initial release. (Closes: #XXXXXX)

--- a/emergency_button/debian/changelog
+++ b/emergency_button/debian/changelog
@@ -1,4 +1,4 @@
-movai-ign-plugin-emergency-button (1.0.1-7) UNRELEASED; urgency=medium
+movai-ign-plugin-emergency-button (1.0.2-0) UNRELEASED; urgency=medium
 
   [ Filipe ]
   * Initial release. (Closes: #XXXXXX)

--- a/emissive_property_controller/debian/changelog
+++ b/emissive_property_controller/debian/changelog
@@ -1,4 +1,4 @@
-movai-ign-plugin-emissive-property-controller (1.0.1-7) UNRELEASED; urgency=medium
+movai-ign-plugin-emissive-property-controller (1.0.2-0) UNRELEASED; urgency=medium
 
   [ Filipe ]
   * Initial release. (Closes: #XXXXXX)

--- a/remove_object/RemoveObject.cc
+++ b/remove_object/RemoveObject.cc
@@ -132,13 +132,11 @@ void RemoveObject::OnTrigger(const ignition::msgs::StringMsg &_msg)
     if (!_msg.data().empty()){
       size_t pos = 0;
       std::string s = _msg.data();
-      int counter = 0;
 
       //Create a vector with model names
       while((pos = s.find(this->delimiter)) != std::string::npos){
         this->vector_name.push_back(s.substr(0,pos)) ;        
         s.erase(0,pos+1);
-        counter++;
       }
       this->remove_object = true;  
     }

--- a/remove_object/RemoveObject.cc
+++ b/remove_object/RemoveObject.cc
@@ -1,5 +1,11 @@
 #include <ignition/plugin/Register.hh>
-
+#include <ignition/gazebo/components/World.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/components/Model.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/ParentEntity.hh>
+#include <string>
+#include <vector>
 #include "RemoveObject.hh"
 
 using namespace ignition;
@@ -42,8 +48,11 @@ void RemoveObject::Configure(const Entity &_entity,
   // Get the components name to create the removal topic subscriber
   std::string palletName = _ecm.Component<components::Name>(_entity)->Data();
   this->worldName = _ecm.Component<components::Name>(worldEntity)->Data();
+  this->srvRemove = std::string("/world/") + this->worldName + "/remove";
+
   //Change name of the topic to subscribe to
   std::string topic = "/model/remove";
+   
 
   // Subscribe to the removal topic
   this->node.Subscribe(topic, &RemoveObject::OnTrigger,
@@ -63,52 +72,87 @@ void RemoveObject::Update(const ignition::gazebo::UpdateInfo &_info,
   // Nothing left to do if paused.
   if (_info.paused)
     return;
-  
-  // Create the ignition service request for the removal service and call it
 
+  // Create the ignition service request for the removal service and call it
     bool result ;
     ignition::msgs::Entity req;
     ignition::msgs::Boolean res;
     int timeout = 100;
+    bool cv = true;
+    std::vector<std::string> v;
+    auto worldEntity = _ecm.EntityByComponents(components::World());
+    const auto models = _ecm.EntitiesByComponents(components::ParentEntity(worldEntity), components::Model());
+
+    // Populate a vector with the models present in the world
+    for(const auto &m: models){
+        v.push_back(_ecm.Component<components::Name>(m)->Data());
+        
+    }
+    // Check if we want to remove objects
     if (this->remove_object)
     {
-        const std::string srvRemove = std::string("/world/") + this->worldName + "/remove";
-        auto entities = _ecm.EntitiesByComponents(components::Name(this->objectName));
-        ignwarn << entities.size() << std::endl;
-        for (int i =0 ;i<entities.size();i++){
-          req.set_id(entities[i]);
+      //Check if models to remove are present in the world
+      for(const auto &m : this->vector_name){
+        if (std::find(v.begin(), v.end(), m) != v.end()){
+
+          //Create removal service request
+          auto entities = _ecm.EntityByComponents(components::Name(m));
+          req.set_id(entities);
           bool temp = this->node.Request(srvRemove, req, timeout,res,result);
-          ignwarn << entities[i] << " removed"<< std::endl;
+
+          if(!temp){
+            ignerr<<"Failed to request removal" << std::endl;
+            break;
+            }
+        }else{
+          ignerr << "Model " << m << " not found in world " << worldEntity << std::endl;
+          continue;
+        }
+      }
+
         }       
-    
-       
-       
-      // ignmsg << "Removed Object" << std::endl;
+        // Set the state to false to only try to remove each object once and clear model names vector
+       this->remove_object = false;
+       this->vector_name.clear();
     }
+void RemoveObject::PostUpdate(const ignition::gazebo::UpdateInfo &/*_info*/,
+                              const ignition::gazebo::EntityComponentManager &_ecm){
 
-  // Set the state to false to only try to remove each object once
-  this->remove_object = false;
-    
+      
+
 }
-
 // //////////////////////////////////////////////////
 /// \brief Callback for removal subscription
 /// \param[in] _msg Message
+
+// void RemoveObject::OnTrigger(const ignition::msgs::StringMsg_V &_msg)
 void RemoveObject::OnTrigger(const ignition::msgs::StringMsg &_msg)
 {
-    if (_msg.data() != ""){
-        this->remove_object = true;
-        this->objectName = _msg.data();
+    // Check if received data is empty
+    if (!_msg.data().empty()){
+      size_t pos = 0;
+      std::string s = _msg.data();
+      int counter = 0;
 
+      //Create a vector with model names
+      while((pos = s.find(this->delimiter)) != std::string::npos){
+        this->vector_name.push_back(s.substr(0,pos)) ;        
+        s.erase(0,pos+1);
+        counter++;
+      }
+      this->remove_object = true;  
     }
+
 }
 
 // Register this plugin
 IGNITION_ADD_PLUGIN(RemoveObject,
                     ignition::gazebo::System,
                     RemoveObject::ISystemConfigure,
-                    RemoveObject::ISystemUpdate)
+                    RemoveObject::ISystemUpdate,
+                    RemoveObject::ISystemPostUpdate)
 
 IGNITION_ADD_PLUGIN_ALIAS(RemoveObject,
                           "ignition::gazebo::systems::RemoveObject")
+
 

--- a/remove_object/RemoveObject.hh
+++ b/remove_object/RemoveObject.hh
@@ -16,7 +16,8 @@ using namespace systems;
 /// \brief Remove Object Plugin that can identify and trigger the removal of the object it is attached to
 class RemoveObject : public ignition::gazebo::System,
     public ignition::gazebo::ISystemConfigure,
-    public ignition::gazebo::ISystemUpdate
+    public ignition::gazebo::ISystemUpdate,
+    public ignition::gazebo::ISystemPostUpdate
 {
   /// \brief Constructor
   public: RemoveObject();
@@ -44,8 +45,11 @@ class RemoveObject : public ignition::gazebo::System,
   //////////////////////////////////////////////////
   /// \brief Callback for removal subscription
   /// \param[in] _msg Message
-  private: void OnTrigger(const ignition::msgs::StringMsg &_msg);
+  // private: void OnTrigger(const ignition::msgs::StringMsg_V &_msg);
+  private: void OnTrigger(const msgs::StringMsg &_msg);
 
+  public: void PostUpdate(const UpdateInfo &/*_info*/,
+                          const EntityComponentManager &_ecm) ;
 
   /// \brief Ignition communication node.
   public: ignition::transport::Node node;
@@ -55,12 +59,21 @@ class RemoveObject : public ignition::gazebo::System,
 
   /// \brief World name in which to remove entities
   public: std::string  worldName;
+
+  /// \brief Vector to populate with models' names 
+  public: std::vector<std::string> vector_name;
   
   /// \brief Boolean to trigger the removal of a specific entity
   public: bool remove_object{false};
 
   /// \brief Model entity that this plugin is attached
   public: Model model{kNullEntity};
+
+  /// \brief Delimiter between model names
+  private: char delimiter{'!'};
+
+  /// \brief Removal service string
+  public: std::string srvRemove;
 };
 
 #endif

--- a/remove_object/debian/changelog
+++ b/remove_object/debian/changelog
@@ -1,4 +1,4 @@
-movai-ign-plugin-remove-object (1.0.1-7) UNRELEASED; urgency=medium
+movai-ign-plugin-remove-object (1.0.2-0) UNRELEASED; urgency=medium
 
   [ Filipe ]
   * Initial release. (Closes: #XXXXXX)

--- a/spawn_model/SpawnModel.cc
+++ b/spawn_model/SpawnModel.cc
@@ -141,11 +141,9 @@ void SpawnModel::OnModelArray(const ignition::msgs::StringMsg &_msg)
       //Create a vector with model names
       size_t pos = 0;
       std::string s = _msg.data();
-      int counter = 0;
       while((pos = s.find(this->delimiter)) != std::string::npos){
         this->model_name.push_back(s.substr(0,pos)) ;        
         s.erase(0,pos+1);
-        counter++;
       }
       this-> string_ready = true;
     }

--- a/spawn_model/SpawnModel.hh
+++ b/spawn_model/SpawnModel.hh
@@ -50,6 +50,7 @@ class SpawnModel : public ignition::gazebo::System,
   /// \param[in] _msg Message
   private: void OnSpawnCmd(const ignition::msgs::Pose_V &_msg);
 
+  private: void OnModelArray(const ignition::msgs::StringMsg &_msg);
 
   /// \brief Ignition communication node.
   public: ignition::transport::Node node;
@@ -61,17 +62,26 @@ class SpawnModel : public ignition::gazebo::System,
   public: std::string  worldName;
   
   /// @brief Object Pose
-  public: ignition::msgs::Quaternion objectOrientation;
+  public: std::vector<ignition::msgs::Quaternion> objectOrientation;
 
-  public: ignition::msgs::Vector3d objectPosition;
+  public: std::vector<ignition::msgs::Vector3d> objectPosition;
   /// @brief Number of objects spawned so far
   public: int nrObjectsSpawned{0};
 
-  /// \brief Spawn trigger variable in the update moment
+  /// \brief Spawn trigger variable in the update function
   public: bool spawnObject{false};
 
   /// \brief Model entity that this plugin is attached
   public: Model model{kNullEntity};
+
+  /// \brief Model names variablle in the update function
+  public: bool string_ready{false};
+ 
+  /// \brief To spawn model names vector 
+  public: std::vector<std::string> model_name;
+
+  /// \brief Character between model names 
+  private: char delimiter{'!'};
 
 };
 

--- a/spawn_model/debian/changelog
+++ b/spawn_model/debian/changelog
@@ -1,4 +1,4 @@
-movai-ign-plugin-spawn-model (1.0.1-7) UNRELEASED; urgency=medium
+movai-ign-plugin-spawn-model (1.0.2-0) UNRELEASED; urgency=medium
 
   [ Filipe ]
   * Initial release. (Closes: #XXXXXX)

--- a/world_launcher/debian/changelog
+++ b/world_launcher/debian/changelog
@@ -1,4 +1,4 @@
-movai-ign-plugin-world-launcher (1.0.1-7) UNRELEASED; urgency=medium
+movai-ign-plugin-world-launcher (1.0.2-0) UNRELEASED; urgency=medium
 
   [ Filipe ]
   * Initial release. (Closes: #XXXXXX)


### PR DESCRIPTION
Update spawn and removal plugins. Both plugins now receive a string with the names of the models to spawn/remove.
Relates to
 [https://movai.atlassian.net/browse/RP-1727](url) 
and
[https://movai.atlassian.net/browse/RP-1728](url)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
