### PR TITLE
Fix LED plugin memory leak

### DIFF
--- a/emissive_property_controller/EmissivePropertyController.cc
+++ b/emissive_property_controller/EmissivePropertyController.cc
@@ -120,15 +120,19 @@ void EmissivePropertyController::PerformRenderingOperations()
     return;
   }
 
-  // Creating the material and setting the Color to Ambient, Diffuse and Emissive proprieties
-  ignition::rendering::MaterialPtr material = this->scene->CreateMaterial();
+  ignition::rendering::MaterialPtr material = visual->Material();
+  if (nullptr == material)
+  {
+    // Creating the material and setting the Color to Ambient, Diffuse and Emissive proprieties
+    material = this->scene->CreateMaterial();
+  }
+
   material->SetAmbient(this->newEmissive);
   material->SetDiffuse(this->newEmissive);
   material->SetEmissive(this->newEmissive);
-
   // Applying the material to the selected visual link.
   visual->SetMaterial(material);
-
+  material->~Material();
   this->materialRequest = false;
 }
 


### PR DESCRIPTION
[RP-1880](https://movai.atlassian.net/browse/RP-1880): [Simulation] EmissivePropertyController causes Ignition gazebo to crash:
  - After setting the material to change the LED color on Tugbot, the material is now destroyed to avoid a simulation crash

[RP-1880]: https://movai.atlassian.net/browse/RP-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ