### PR TITLE
Extend spawn plugin

### DIFF
--- a/spawn_model/SpawnModel.hh
+++ b/spawn_model/SpawnModel.hh
@@ -7,6 +7,11 @@
 #include <ignition/common/Profiler.hh>
 #include "ignition/gazebo/components/Name.hh"
 #include "ignition/gazebo/components/World.hh"
+#include <ignition/gazebo/components/ParentEntity.hh>
+#include <ignition/gazebo/components/Model.hh>
+#include <ignition/gazebo/components/Pose.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/msgs/Utility.hh>
 
 
 using namespace ignition;
@@ -16,7 +21,8 @@ using namespace systems;
 /// \brief Spawn Object Plugin that can identify and trigger the creation of the object it is attached to
 class SpawnModel : public ignition::gazebo::System,
     public ignition::gazebo::ISystemConfigure,
-    public ignition::gazebo::ISystemUpdate
+    public ignition::gazebo::ISystemUpdate,
+    public ignition::gazebo::ISystemPostUpdate
 {
   /// \brief Constructor
   public: SpawnModel();
@@ -43,7 +49,8 @@ class SpawnModel : public ignition::gazebo::System,
   public: void Update(const ignition::gazebo::UpdateInfo &_info,
               ignition::gazebo::EntityComponentManager &_ecm);
 
-
+  public: void PostUpdate(const ignition::gazebo::UpdateInfo &_info,
+              const ignition::gazebo::EntityComponentManager &_ecm);
 
   //////////////////////////////////////////////////
   /// \brief Callback for spawn topic subscription
@@ -52,8 +59,16 @@ class SpawnModel : public ignition::gazebo::System,
 
   private: void OnModelArray(const ignition::msgs::StringMsg &_msg);
 
+  private: void OnMoveCmd(const ignition::msgs::Pose &_msg);
+
+  private: void OnModelName(const ignition::msgs::StringMsg &_msg);
+
+  private: void OnModelPoseReq(const ignition::msgs::StringMsg &_msg);
+
   /// \brief Ignition communication node.
   public: ignition::transport::Node node;
+
+  public: transport::Node::Publisher PosePub;
 
   /// \brief Name of the model to spawn
    public: std::string  objectName;
@@ -82,6 +97,21 @@ class SpawnModel : public ignition::gazebo::System,
 
   /// \brief Character between model names 
   private: char delimiter{'!'};
+
+  /// \brief Variables to store the desired pose of a model to be moved 
+  public: double qx;
+  public: double qy;
+  public: double qw;
+  public: double qz;
+
+  public: double x;
+  public: double y;
+  public: double z;
+
+  /// \brief Variables to allow a model to be moved
+  public: std::string move_model_name;
+  public: bool move_model_name_ready{false};
+  public: std::string search_model;
 
 };
 


### PR DESCRIPTION
Extend the spawn plugin to be able to move models dynamically and retrieves the pose of a specific model in the simulated world
